### PR TITLE
Improved oven argparser to be automatically correctly typed

### DIFF
--- a/code/PyBake/__main__.py
+++ b/code/PyBake/__main__.py
@@ -7,6 +7,7 @@ if __name__ != '__main__':
 import sys
 import argparse
 import textwrap
+from PyBake import Path
 
 ## Data for Argparser
 
@@ -76,7 +77,7 @@ def execute_oven(args):
     print("Executing oven")
     print(args)
     from PyBake import oven, Path
-    oven.run(Path(args.working_dir), Path(args.recipe), Path(args.output), args.indent_output)
+    oven.run(**vars(args))
 
 
 ## Main Parser
@@ -96,13 +97,13 @@ subparsers.required = True
 ## ====
 ovenParser = subparsers.add_parser("oven", help=ovenDescription, description=ovenDescription)
 
-ovenParser.add_argument("-r", "--recipe", default="recipe.py",
+ovenParser.add_argument("-r", "--recipe", type=Path, default=Path("recipe.py"),
                         help="Supply the path to a custom recipe relative to the working dir. Defaults to recipe.py.")
-ovenParser.add_argument("-o", "--output", default="pastry.json",
+ovenParser.add_argument("-o", "--output", type=Path, default=Path("pastry.json"),
                         help="The resulting JSON file relative to the working dir.")
-ovenParser.add_argument("-d", "--working-dir", default=".",
+ovenParser.add_argument("-d", "--working-dir", type=Path, default=Path("."),
                         help="The working directory.")
-ovenParser.add_argument("--indent-output", default=True,
+ovenParser.add_argument("--indent-output", type=bool, default=True,
                         help="Whether to produce a more human-friendly, indented JSON file.")
 ovenParser.set_defaults(func=execute_oven)
 

--- a/code/PyBake/oven.py
+++ b/code/PyBake/oven.py
@@ -6,22 +6,22 @@ import sys
 from importlib import import_module
 from PyBake import *
 
-def run(workingDir, recipeScript, jsonTarget, indentOutput):
-    # Make sure the recipeScript exists.
-    recipePath = Path(recipeScript).resolve()
+def run(*, working_dir, recipe, output, indent_output, **kwargs):
+    # Make sure the recipe exists.
+    recipePath = recipe.resolve()
 
     # Remove the file extension.
-    recipeScript = recipeScript.parent / recipeScript.stem
+    recipe = recipe.parent / recipe.stem
 
     # Make sure the working dir exists.
-    workingDir = Path(workingDir).resolve()
+    working_dir = working_dir.resolve()
 
     # Change into the working directory given by the user.
-    with ChangeDir(workingDir):
-        print("Processing recipe '{0}'".format(recipeScript))
+    with ChangeDir(working_dir):
+        print("Processing recipe '{0}'".format(recipe))
 
         # Load the recipe, which will register some handlers that yield ingredients.
-        recipe = import_module(recipeScript.as_posix())
+        recipe = import_module(recipe.as_posix())
         if len(recipes) == 0:
             print("No recipes found. Make sure to create functions and decorate them with @recipe.")
             return
@@ -37,5 +37,5 @@ def run(workingDir, recipeScript, jsonTarget, indentOutput):
         )
 
     # Write the JSON file (pastry.json by default).
-    with jsonTarget.open("w") as outfile:
-        json.dump(pastry, outfile, cls=Baker, indent=indentOutput)
+    with output.open("w") as outfile:
+        json.dump(pastry, outfile, cls=Baker, indent=indent_output)


### PR DESCRIPTION
and value parsing to oven run is more maintainable

This changes automatically create pathlib Paths out of the arguments without an extra Path() call.
Also oven.run(...) call never needs to be touched again when adding arguments because the values are now all named arguments and get unpacked directly from the arguments.

The only drawback is that the argument names need to be called exactly as the command line flags.